### PR TITLE
Support exec and add basic logic implementations

### DIFF
--- a/src/lang/ast.rs
+++ b/src/lang/ast.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub enum AstNode {
     Leaf(String),
     AST(Vec<AstNode>),

--- a/src/lang/base/logic.rs
+++ b/src/lang/base/logic.rs
@@ -1,0 +1,238 @@
+use crate::lang::{
+    ast::AstNode,
+    exec::{Program, Result, Scope},
+};
+
+pub fn ifdef(args: Vec<AstNode>, scope: &Scope) -> Option<Result> {
+    if args.len() < 2 || args.len() > 3 {
+        panic!(
+            "Incorrect number of arguments to function <if>, expected 2 or 3, received {}",
+            args.len()
+        );
+    }
+
+    let gate = Program::new(vec![args[0].clone()], &scope).exec();
+
+    // Everything except #f is true
+    if gate != Some(Result::B(false)) {
+        Program::new(vec![args[1].clone()], &scope).exec()
+    } else {
+        if args.len() == 3 {
+            Program::new(vec![args[2].clone()], &scope).exec()
+        } else {
+            None
+        }
+    }
+}
+
+pub fn eqhuhdef(args: Vec<AstNode>, scope: &Scope) -> Option<Result> {
+    if args.len() != 2 {
+        panic!(
+            "Incorrect number of arguments to function <eq?>, expected 2, received {}",
+            args.len()
+        )
+    }
+
+    let cmp = Program::new(vec![args[0].clone()], &scope).exec();
+    let to = Program::new(vec![args[1].clone()], &scope).exec();
+
+    match cmp {
+        Some(cmpresult) => match to {
+            Some(toresult) => Some(Result::B(cmpresult == toresult)),
+            None => Some(Result::B(false)),
+        },
+        None => match to {
+            Some(_) => Some(Result::B(false)),
+            None => Some(Result::B(true)),
+        },
+    }
+}
+
+/*
+* TODO: reimplement in pure risk once `not` and `define` are implemented
+*/
+pub fn neqhuhdef(args: Vec<AstNode>, scope: &Scope) -> Option<Result> {
+    match eqhuhdef(args, &scope) {
+        Some(eq) => match eq {
+            Result::B(res) => Some(Result::B(!res)),
+            _ => Some(Result::B(false)),
+        },
+        None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod ifdef {
+        use super::super::*;
+
+        #[test]
+        fn if_happy_path() {
+            assert_eq!(
+                ifdef(
+                    vec![
+                        AstNode::Leaf("#t".to_string()),
+                        AstNode::Leaf("1".to_string()),
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::I(1)
+            )
+        }
+
+        #[test]
+        fn if_with_else() {
+            assert_eq!(
+                ifdef(
+                    vec![
+                        AstNode::Leaf("#t".to_string()),
+                        AstNode::Leaf("1".to_string()),
+                        AstNode::Leaf("2".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::I(1)
+            )
+        }
+
+        #[test]
+        fn if_returns_else_when_strictly_false() {
+            assert_eq!(
+                ifdef(
+                    vec![
+                        AstNode::Leaf("#f".to_string()),
+                        AstNode::Leaf("1".to_string()),
+                        AstNode::Leaf("2".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::I(2)
+            )
+        }
+
+        #[test]
+        fn if_anything_but_false_is_true() {
+            assert_eq!(
+                ifdef(
+                    vec![
+                        AstNode::Leaf("88".to_string()),
+                        AstNode::Leaf("1".to_string()),
+                        AstNode::Leaf("2".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::I(1)
+            );
+        }
+    }
+
+    mod eqhuhdef {
+        use super::super::*;
+
+        #[test]
+        fn eqhuh_bool_equality() {
+            assert_eq!(
+                eqhuhdef(
+                    vec![
+                        AstNode::Leaf("#t".to_string()),
+                        AstNode::Leaf("#t".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::B(true)
+            );
+
+            assert_eq!(
+                eqhuhdef(
+                    vec![
+                        AstNode::Leaf("#f".to_string()),
+                        AstNode::Leaf("#f".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::B(true)
+            );
+        }
+
+        #[test]
+        fn eqhuh_bool_inequality() {
+            assert_eq!(
+                eqhuhdef(
+                    vec![
+                        AstNode::Leaf("#f".to_string()),
+                        AstNode::Leaf("#t".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::B(false)
+            );
+        }
+
+        #[test]
+        fn eqhuh_int_equlaity() {
+            assert_eq!(
+                eqhuhdef(
+                    vec![
+                        AstNode::Leaf("100".to_string()),
+                        AstNode::Leaf("100".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::B(true)
+            );
+        }
+
+        #[test]
+        fn eqhuh_int_inequlaity() {
+            assert_eq!(
+                eqhuhdef(
+                    vec![
+                        AstNode::Leaf("100".to_string()),
+                        AstNode::Leaf("200".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::B(false)
+            );
+        }
+
+        #[test]
+        fn eqhuh_float_equality() {
+            assert_eq!(
+                eqhuhdef(
+                    vec![
+                        AstNode::Leaf("100.1".to_string()),
+                        AstNode::Leaf("100.1".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::B(true)
+            );
+        }
+
+        #[test]
+        fn eqhuh_float_inequality() {
+            assert_eq!(
+                eqhuhdef(
+                    vec![
+                        AstNode::Leaf("100.1".to_string()),
+                        AstNode::Leaf("200.2".to_string())
+                    ],
+                    &Scope::base()
+                )
+                .unwrap(),
+                Result::B(false)
+            );
+        }
+    }
+}

--- a/src/lang/base/mod.rs
+++ b/src/lang/base/mod.rs
@@ -1,0 +1,1 @@
+pub mod logic;

--- a/src/lang/exec.rs
+++ b/src/lang/exec.rs
@@ -1,0 +1,170 @@
+use crate::lang::base;
+use std::{collections::HashMap, fmt::Display};
+
+use crate::lang::ast::AstNode;
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Result {
+    S(String),
+    I(i32),
+    F(f64),
+    B(bool),
+}
+
+impl Display for Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Result::S(s) => write!(f, "{}", s),
+            Result::I(i) => write!(f, "{}", i),
+            Result::F(fl) => write!(f, "{}", fl),
+            Result::B(b) => match b {
+                true => write!(f, "#t"),
+                false => write!(f, "#f"),
+            },
+        }
+    }
+}
+
+enum Scopable {
+    Result(Result),
+    Callback(fn(args: Vec<AstNode>, scope: &Scope) -> Option<Result>),
+}
+
+pub struct Program<'a> {
+    scope: &'a Scope,
+    ast: Vec<AstNode>,
+}
+
+pub struct Scope {
+    map: HashMap<String, Scopable>,
+}
+
+impl Program<'_> {
+    pub fn exec(&self) -> Option<Result> {
+        match &self.ast.clone()[..] {
+            [] => None,
+            [a] => match a {
+                AstNode::Leaf(l) => match l.parse::<i32>() {
+                    Ok(i) => Some(Result::I(i)),
+                    Err(_) => match l.parse::<f64>() {
+                        Ok(f) => Some(Result::F(f)),
+                        Err(_) => match self.scope.map.get(l) {
+                            Some(v) => match v {
+                                Scopable::Result(r) => Some(r.to_owned()),
+                                Scopable::Callback(c) => c(vec![], &self.scope),
+                            },
+                            None => panic!("Reference to undefined variable {}", l),
+                        },
+                    },
+                },
+                AstNode::AST(ast_nodes) => Program::new(ast_nodes.to_vec(), &self.scope).exec(),
+            },
+            [f, rest @ ..] => match f {
+                AstNode::Leaf(f) => match self.scope.map.get(f) {
+                    Some(s) => match s {
+                        Scopable::Result(r) => panic!("Call to primitive {} as function", r),
+                        Scopable::Callback(c) => c(rest.to_vec(), self.scope),
+                    },
+                    None => panic!("Call to undefined function <{}>", f),
+                },
+                AstNode::AST(ast_nodes) => {
+                    match Program::new(ast_nodes.to_vec(), self.scope).exec() {
+                        Some(r) => match r {
+                            Result::S(s) => match self.scope.map.get(&s) {
+                                Some(v) => match v {
+                                    Scopable::Result(r) => Some(r.to_owned()),
+                                    Scopable::Callback(c) => c(vec![], &self.scope),
+                                },
+                                None => panic!("Reference to undefined variable {}", s),
+                            },
+
+                            p => panic!("Call to primitive {} as function", p),
+                        },
+                        None => panic!("Call to '()"),
+                    }
+                }
+            },
+        }
+    }
+
+    pub fn new(ast: Vec<AstNode>, scope: &Scope) -> Program<'_> {
+        Program {
+            scope: scope,
+            ast: ast,
+        }
+    }
+}
+
+impl Scope {
+    pub fn base() -> Scope {
+        let mut base_scope: Scope = Scope {
+            map: HashMap::new(),
+        };
+
+        // bools
+        base_scope
+            .map
+            .insert(String::from("#t"), Scopable::Result(Result::B(true)));
+
+        base_scope
+            .map
+            .insert(String::from("#f"), Scopable::Result(Result::B(false)));
+
+        // logic functions
+        base_scope
+            .map
+            .insert(String::from("if"), Scopable::Callback(base::logic::ifdef));
+
+        base_scope.map.insert(
+            String::from("eq?"),
+            Scopable::Callback(base::logic::eqhuhdef),
+        );
+
+        base_scope.map.insert(
+            String::from("neq?"),
+            Scopable::Callback(base::logic::neqhuhdef),
+        );
+
+        base_scope
+    }
+}
+
+pub fn exec(ast: Vec<AstNode>) -> Option<Result> {
+    Program::new(ast, &Scope::base()).exec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execs_basic_sexp() {
+        assert_eq!(
+            exec(vec![
+                AstNode::Leaf("if".to_string()),
+                AstNode::Leaf("#t".to_string()),
+                AstNode::Leaf("1".to_string())
+            ])
+            .unwrap(),
+            Result::I(1)
+        )
+    }
+
+    #[test]
+    fn execs_nested_sexp() {
+        assert_eq!(
+            exec(vec![
+                AstNode::Leaf("if".to_string()),
+                AstNode::AST(vec![
+                    AstNode::Leaf("if".to_string()),
+                    AstNode::Leaf("1".to_string()),
+                    AstNode::Leaf("#f".to_string())
+                ]),
+                AstNode::Leaf("1".to_string()),
+                AstNode::Leaf("2".to_string())
+            ])
+            .unwrap(),
+            Result::I(2)
+        )
+    }
+}

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -1,2 +1,4 @@
 pub mod ast;
+pub mod base;
+pub mod exec;
 pub mod token;

--- a/src/lang/token.rs
+++ b/src/lang/token.rs
@@ -14,12 +14,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_tokenize_single_token() {
+    fn tokenize_single_token() {
         assert_eq!(tokenize("token"), ["token"]);
     }
 
     #[test]
-    fn test_tokenize_list_of_tokens() {
+    fn tokenize_list_of_tokens() {
         assert_eq!(
             tokenize("(1 2 3)) 1 token"),
             ["(", "1", "2", "3", ")", ")", "1", "token"]
@@ -27,7 +27,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tokenize_strips_excess_whitespace() {
+    fn tokenize_strips_excess_whitespace() {
         assert_eq!(
             tokenize("( 1 2    3) ) () ) 1 token"),
             ["(", "1", "2", "3", ")", ")", "(", ")", ")", "1", "token"]
@@ -35,7 +35,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tokenize_handles_newline_and_tabs() {
+    fn tokenize_handles_newline_and_tabs() {
         assert_eq!(
             tokenize(
                 "( 1 2 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,24 @@
-use crate::lang::{ast, token};
+use crate::lang::{ast, exec, token};
 use std::io;
 
 pub mod lang;
 
 fn main() {
-    println!("Enter lisp: ");
-    let mut to_exec = String::new();
-    io::stdin()
-        .read_line(&mut to_exec)
-        .expect("Failed to read line");
+    loop {
+        println!("Enter lisp: ");
+        let mut to_exec = String::new();
+        io::stdin()
+            .read_line(&mut to_exec)
+            .expect("Failed to read line");
 
-    let res: Vec<ast::AstNode>;
+        let res: Option<exec::Result>;
 
-    if let Some(cleaned) = to_exec.strip_suffix("\n") {
-        res = ast::new(token::tokenize(cleaned));
-    } else {
-        res = ast::new(token::tokenize(&to_exec));
+        if let Some(cleaned) = to_exec.strip_suffix("\n") {
+            res = exec::exec(ast::new(token::tokenize(cleaned)));
+        } else {
+            res = exec::exec(ast::new(token::tokenize(&to_exec)));
+        }
+
+        println!("{}", res.unwrap());
     }
-
-    dbg!(res);
 }


### PR DESCRIPTION
This adds `exec(Vec<AstNode>)` to create and execute a program. It also adds some basic standard library functions - namely `if`, `eq?` and `neq?`. Likely `neq?` could be implemented in pure risk if `not` is implemented. (`(define (neq x y) (not (eq? x y)))`, however, definition is not supported yet so a todo has been added.