### PR TITLE
Support definition, fix calling AstNode::Leaf bug

### DIFF
--- a/src/lang/base/definition.rs
+++ b/src/lang/base/definition.rs
@@ -1,0 +1,159 @@
+use crate::lang::{
+    ast::AstNode,
+    exec::Program,
+    scope::Scope,
+    types::{result::Result, userfunc::FnDef},
+};
+
+/*
+* Used to define functions and variables
+*
+* The following forms are supported
+*
+* (define (fn params...) expr) => None
+* (define var expr) => None
+*/
+pub fn definitiondef(args: Vec<AstNode>, scope: &mut Scope) -> Option<Result> {
+    match &args[..] {
+        [] => panic!("Empty call to define"),
+        [_] => panic!("Must provide right hand side to set the left hand side to"),
+        [subject, expr] => match subject {
+            AstNode::Leaf(varname) => {
+                let val = Program::new(expr.to_owned(), scope).exec();
+
+                match val {
+                    Some(result) => {
+                        scope.map.insert(varname.to_string(), result);
+                        None
+                    }
+                    None => panic!("Right hand side evaluated to nothing"),
+                }
+            }
+            AstNode::AST(function_signature) => match &function_signature[..] {
+                [] => panic!("Must provide function name"),
+                [fname, params @ ..] => match fname {
+                    AstNode::Leaf(n) => {
+                        let str_params = params.iter().map(|p| match p {
+                            AstNode::Leaf(p) => p.to_string(),
+                            AstNode::AST(_) => {
+                                panic!("All function parameters must be simple strings")
+                            }
+                        });
+
+                        scope.map.insert(
+                            n.to_string(),
+                            Result::FnDef(FnDef::new(str_params.collect(), expr.clone())),
+                        );
+                        None
+                    }
+                    AstNode::AST(_) => panic!("Cannot use an expression as function name"),
+                },
+            },
+        },
+        _ => panic!("define can only be called with two parameters"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lang::types::primitive::Primitive;
+
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn definitiondef_panics_empty_call() {
+        definitiondef(vec![], &mut Scope::base());
+    }
+
+    #[test]
+    #[should_panic]
+    fn definitiondef_panics_missing_rhs() {
+        definitiondef(vec![AstNode::Leaf("x".to_string())], &mut Scope::base());
+    }
+
+    #[test]
+    fn definitiondef_defines_variable() {
+        let s = &mut Scope::base();
+        definitiondef(
+            vec![
+                AstNode::Leaf("x".to_string()),
+                AstNode::AST(vec![
+                    AstNode::Leaf("if".to_string()),
+                    AstNode::Leaf("#t".to_string()),
+                    AstNode::Leaf("1".to_string()),
+                ]),
+            ],
+            s,
+        );
+
+        assert_eq!(
+            Program::new(AstNode::Leaf("x".to_string()), s)
+                .exec()
+                .unwrap(),
+            Result::Primitive(Primitive::I(1))
+        )
+    }
+
+    #[test]
+    fn definitiondef_defines_userfunc_with_no_params() {
+        let s = &mut Scope::base();
+        definitiondef(
+            vec![
+                AstNode::AST(vec![AstNode::Leaf("func".to_string())]),
+                AstNode::AST(vec![
+                    AstNode::Leaf("if".to_string()),
+                    AstNode::Leaf("#t".to_string()),
+                    AstNode::Leaf("1".to_string()),
+                ]),
+            ],
+            s,
+        );
+
+        assert_eq!(
+            Program::new(AstNode::AST(vec![AstNode::Leaf("func".to_string())]), s)
+                .exec()
+                .unwrap(),
+            Result::Primitive(Primitive::I(1))
+        )
+    }
+
+    #[test]
+    fn definitiondef_defines_userfunc_with_params() {
+        let s = &mut Scope::base();
+        definitiondef(
+            vec![
+                AstNode::AST(vec![
+                    AstNode::Leaf("func".to_string()),
+                    AstNode::Leaf("x".to_string()),
+                    AstNode::Leaf("y".to_string()),
+                ]),
+                AstNode::AST(vec![
+                    AstNode::Leaf("if".to_string()),
+                    AstNode::AST(vec![
+                        AstNode::Leaf("eq?".to_string()),
+                        AstNode::Leaf("x".to_string()),
+                        AstNode::Leaf("y".to_string()),
+                    ]),
+                    AstNode::Leaf("1".to_string()),
+                    AstNode::Leaf("2".to_string()),
+                ]),
+            ],
+            s,
+        );
+
+        assert_eq!(
+            Program::new(
+                AstNode::AST(vec![
+                    AstNode::Leaf("func".to_string()),
+                    AstNode::Leaf("1".to_string()),
+                    AstNode::Leaf("2".to_string())
+                ]),
+                s
+            )
+            .exec()
+            .unwrap(),
+            Result::Primitive(Primitive::I(2))
+        )
+    }
+}

--- a/src/lang/base/mod.rs
+++ b/src/lang/base/mod.rs
@@ -1,1 +1,2 @@
+pub mod definition;
 pub mod logic;

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -1,4 +1,6 @@
 pub mod ast;
 pub mod base;
 pub mod exec;
+pub mod scope;
 pub mod token;
+pub mod types;

--- a/src/lang/scope.rs
+++ b/src/lang/scope.rs
@@ -1,0 +1,63 @@
+use crate::lang::base;
+use crate::lang::types::builtin::Builtin;
+use crate::lang::types::primitive::Primitive;
+use crate::lang::types::result::Result;
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub struct Scope {
+    pub map: HashMap<String, Result>,
+}
+
+impl Scope {
+    pub fn base() -> Scope {
+        let mut base_scope: Scope = Scope {
+            map: HashMap::new(),
+        };
+
+        // bools
+        base_scope
+            .map
+            .insert(String::from("#t"), Result::Primitive(Primitive::B(true)));
+
+        base_scope
+            .map
+            .insert(String::from("#f"), Result::Primitive(Primitive::B(false)));
+
+        // definition
+        base_scope.map.insert(
+            String::from("define"),
+            Result::Builtin(Builtin {
+                id: "define".to_string(),
+                f: base::definition::definitiondef,
+            }),
+        );
+
+        // logic functions
+        base_scope.map.insert(
+            String::from("if"),
+            Result::Builtin(Builtin {
+                id: "if".to_string(),
+                f: base::logic::ifdef,
+            }),
+        );
+
+        base_scope.map.insert(
+            String::from("eq?"),
+            Result::Builtin(Builtin {
+                id: "eq?".to_string(),
+                f: base::logic::eqhuhdef,
+            }),
+        );
+
+        base_scope.map.insert(
+            String::from("not"),
+            Result::Builtin(Builtin {
+                id: "not".to_string(),
+                f: base::logic::notdef,
+            }),
+        );
+
+        base_scope
+    }
+}

--- a/src/lang/token.rs
+++ b/src/lang/token.rs
@@ -1,6 +1,6 @@
 pub fn tokenize(line: &str) -> Vec<String> {
-    line.replace("(", "( ")
-        .replace(")", " )")
+    line.replace("(", " ( ")
+        .replace(")", " ) ")
         .replace("\n", " ")
         .replace("\t", " ")
         .split(" ")
@@ -42,6 +42,14 @@ mod tests {
                 )"
             ),
             ["(", "1", "2", "3", ")"]
+        );
+    }
+
+    #[test]
+    fn tokenize_handles_touching_sexps() {
+        assert_eq!(
+            tokenize("(1 2 3)(1)"),
+            ["(", "1", "2", "3", ")", "(", "1", ")"]
         );
     }
 }

--- a/src/lang/types/builtin.rs
+++ b/src/lang/types/builtin.rs
@@ -1,0 +1,44 @@
+use crate::lang::{ast::AstNode, scope::Scope, types::result::Result};
+
+#[derive(Debug, Clone)]
+pub struct Builtin {
+    pub id: String,
+    pub f: fn(Vec<AstNode>, &mut Scope) -> Option<Result>,
+}
+
+impl PartialEq for Builtin {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eq_on_same_id() {
+        let l = Builtin {
+            id: "id".to_string(),
+            f: |_v: Vec<AstNode>, _s: &mut Scope| None,
+        };
+        let r = Builtin {
+            id: "id".to_string(),
+            f: |_v: Vec<AstNode>, _s: &mut Scope| None,
+        };
+        assert!(l == r);
+    }
+
+    #[test]
+    fn not_eq_based_on_id() {
+        let l = Builtin {
+            id: "id".to_string(),
+            f: |_v: Vec<AstNode>, _s: &mut Scope| None,
+        };
+        let r = Builtin {
+            id: "id2".to_string(),
+            f: |_v: Vec<AstNode>, _s: &mut Scope| None,
+        };
+        assert!(l != r);
+    }
+}

--- a/src/lang/types/mod.rs
+++ b/src/lang/types/mod.rs
@@ -1,0 +1,4 @@
+pub mod builtin;
+pub mod primitive;
+pub mod result;
+pub mod userfunc;

--- a/src/lang/types/primitive.rs
+++ b/src/lang/types/primitive.rs
@@ -1,0 +1,6 @@
+#[derive(PartialEq, Debug, Clone)]
+pub enum Primitive {
+    I(i32),
+    F(f64),
+    B(bool),
+}

--- a/src/lang/types/result.rs
+++ b/src/lang/types/result.rs
@@ -1,0 +1,29 @@
+use std::fmt::Display;
+
+use crate::lang::types::{builtin::Builtin, primitive::Primitive, userfunc::FnDef};
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Result {
+    Primitive(Primitive),
+    Builtin(Builtin),
+    FnDef(FnDef),
+}
+
+impl Display for Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Result::Primitive(p) => match p {
+                Primitive::I(i) => write!(f, "{}", i),
+                Primitive::F(fl) => write!(f, "{}", fl),
+                Primitive::B(b) => match b {
+                    true => write!(f, "#t"),
+                    false => write!(f, "#f"),
+                },
+            },
+            Result::Builtin(func) => write!(f, "builtin#{}", func.id),
+            Result::FnDef(fn_def) => {
+                write!(f, "userfuncdef#{:?}{:?}", fn_def.params, fn_def.body)
+            }
+        }
+    }
+}

--- a/src/lang/types/userfunc.rs
+++ b/src/lang/types/userfunc.rs
@@ -1,0 +1,119 @@
+use crate::lang::{ast::AstNode, exec::Program, scope::Scope, types::result::Result};
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct FnDef {
+    pub params: Vec<String>,
+    pub body: AstNode,
+}
+
+impl FnDef {
+    pub fn exec(&self, args: Vec<AstNode>, scope: &mut Scope) -> Option<Result> {
+        // todo: explore something better than duplicating the entire scope
+        let mut local_scope = scope.clone();
+        if args.len() != self.params.len() {
+            panic!(
+                "Incorrect number of arguments provided. Expected {}, received {}",
+                self.params.len(),
+                args.len()
+            )
+        }
+
+        for (i, param) in self.params.clone().iter().enumerate() {
+            match Program::new(args[i].clone(), scope).exec() {
+                Some(s) => local_scope.map.insert(param.to_string(), s),
+                None => panic!("Cannot pass none to function"),
+            };
+        }
+
+        Program::new(self.body.clone(), &mut local_scope).exec()
+    }
+
+    pub fn new(params: Vec<String>, body: AstNode) -> FnDef {
+        FnDef {
+            params: params,
+            body: body,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::types::primitive::Primitive;
+
+    #[test]
+    fn fn_def_exec_with_no_params_or_args() {
+        let f = FnDef::new(vec![], AstNode::Leaf("2".to_string()));
+
+        assert_eq!(
+            f.exec(vec![], &mut Scope::base()).unwrap(),
+            Result::Primitive(Primitive::I(2))
+        )
+    }
+
+    #[test]
+    #[should_panic]
+    fn fn_def_fails_with_mismatched_params_and_args() {
+        let f = FnDef::new(
+            vec!["x".to_string(), "y".to_string()],
+            AstNode::Leaf("2".to_string()),
+        );
+
+        assert_eq!(
+            f.exec(vec![], &mut Scope::base()).unwrap(),
+            Result::Primitive(Primitive::I(2))
+        )
+    }
+
+    #[test]
+    fn fn_def_applies_args_to_params() {
+        let f = FnDef::new(
+            vec!["x".to_string(), "y".to_string()],
+            AstNode::AST(vec![
+                AstNode::Leaf("eq?".to_string()),
+                AstNode::Leaf("x".to_string()),
+                AstNode::Leaf("y".to_string()),
+            ]),
+        );
+
+        assert_eq!(
+            f.exec(
+                vec![
+                    AstNode::Leaf("1".to_string()),
+                    AstNode::Leaf("1".to_string())
+                ],
+                &mut Scope::base()
+            )
+            .unwrap(),
+            Result::Primitive(Primitive::B(true))
+        )
+    }
+
+    #[test]
+    fn fn_def_args_can_evaluate_themselves() {
+        let f = FnDef::new(
+            vec!["x".to_string(), "y".to_string()],
+            AstNode::AST(vec![
+                AstNode::Leaf("eq?".to_string()),
+                AstNode::Leaf("x".to_string()),
+                AstNode::Leaf("y".to_string()),
+            ]),
+        );
+
+        assert_eq!(
+            f.exec(
+                vec![
+                    AstNode::AST(vec![
+                        AstNode::Leaf("if".to_string()),
+                        AstNode::Leaf("#t".to_string()),
+                        AstNode::Leaf("1".to_string()),
+                    ]),
+                    AstNode::Leaf("1".to_string())
+                ],
+                &mut Scope::base()
+            )
+            .unwrap(),
+            Result::Primitive(Primitive::B(true))
+        )
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,17 @@
-use crate::lang::{ast, exec, token};
+use crate::lang::{
+    ast,
+    exec::{self},
+    scope::Scope,
+    token,
+    types::result::Result,
+};
 use std::io;
 
 pub mod lang;
 
 fn main() {
+    let mut persistent_state = Scope::base();
+
     loop {
         println!("Enter lisp: ");
         let mut to_exec = String::new();
@@ -11,14 +19,23 @@ fn main() {
             .read_line(&mut to_exec)
             .expect("Failed to read line");
 
-        let res: Option<exec::Result>;
+        let res: Option<Result>;
 
         if let Some(cleaned) = to_exec.strip_suffix("\n") {
-            res = exec::exec(ast::new(token::tokenize(cleaned)));
+            res = exec::exec(
+                ast::new(token::tokenize(cleaned)),
+                Some(&mut persistent_state),
+            );
         } else {
-            res = exec::exec(ast::new(token::tokenize(&to_exec)));
+            res = exec::exec(
+                ast::new(token::tokenize(&to_exec)),
+                Some(&mut persistent_state),
+            );
         }
 
-        println!("{}", res.unwrap());
+        match res {
+            Some(r) => println!("{}", r),
+            None => println!(""),
+        }
     }
 }


### PR DESCRIPTION
This adds support for definition of variabled and functions via the form `(define var expr)` and `(define (func ...params) body)`

It also fixes a bug where `Primitive::S` values would call themselves even if not in a function execution context (`if` vs `(if)`). Now `ref` returns the reference it is and execution is gated by parens as it should be.